### PR TITLE
Custom API for evictions

### DIFF
--- a/django_app/landlord_finder/serializers.py
+++ b/django_app/landlord_finder/serializers.py
@@ -1,9 +1,0 @@
-from rest_framework import serializers
-from .models import Landlord
-
-class LandlordSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Landlord
-        fields = (
-                'name',
-                )

--- a/django_app/landlord_finder/views.py
+++ b/django_app/landlord_finder/views.py
@@ -1,8 +1,7 @@
-from django.shortcuts import render
+from .models import Landlord, Address, Case
 from django.views.generic import ListView, DetailView, TemplateView
-from .models import Landlord, Address
-from .serializers import LandlordSerializer
-from rest_framework.generics import ListCreateAPIView
+from rest_framework.views import APIView
+from rest_framework.response import Response
 
 
 class LandlordListView(ListView):
@@ -12,14 +11,26 @@ class LandlordListView(ListView):
 class AddressDetailView(DetailView):
     model = Address
 
+class LandlordListCreate(APIView):
 
-class LandlordListCreate(ListCreateAPIView):
-    queryset = Landlord.objects.all()
-    serializer_class = LandlordSerializer
-
-    # landlord.case_set.all
-    # for address in landlord.case_set.all
-
+    def get(self, request, format=None):
+        data = []
+        for case in Case.objects.all():
+            data.append({
+                            "caseID": case.case_id,
+                            "address": {
+                                "addressLine1": case.address.address1,
+                                "addressLine2": case.address.address2,
+                                "addressLine3": case.address.address3,
+                                "zip": case.address.zip_code,
+                                "city": case.address.city,
+                                "state": case.address.state
+                                },
+                            "plaintiff": case.landlord.name,
+                            "filingDate": case.filing_date,
+                            "moveoutDate": case.moveout_date 
+                    })
+        return Response(data)
 
 class WelcomePageView(TemplateView):
     template_name = 'landlord_finder/welcome.html'


### PR DESCRIPTION
API is update so it now serves data in the following format at `/api/landlords`:

```
{
    "caseID": ,
    "address": {
        "addressLine1": ,
        "addressLine2": ,
        "addressLine3": ,
        "zip": ,
        "city": ,
        "state": 
        },
    "plaintiff": ,
    "filingDate": ,
    "moveoutDate":  
}
```

Deleted `serializers.py` because we are no longer using default serializers, but returning custom JSON in `views.py`.

## How to test:

1. Checkout branch `jason/custom_landlord_api` (make sure you git pull first)

2. navigate to `RentersApp\django_app`

3. `python manage.py runserver`

4. Navigate to `http://localhost:8000/api/landlords/` in a browser

5. You should see the picture below

Picture:
![image](https://user-images.githubusercontent.com/37601333/78949140-b9db5c00-7a98-11ea-8edd-8ac180c52e1b.png)


Huzzah!